### PR TITLE
Fix filters that use Spell IDs

### DIFF
--- a/ElvUI/core/core.lua
+++ b/ElvUI/core/core.lua
@@ -51,6 +51,9 @@ E.TexCoords = {.08, .92, .08, .92};
 E.CreditsList = {};
 E.PixelMode = false;
 
+-- TBC spell id filter fix
+E.spellnametoid = {}
+
 E.InversePoints = {
 	TOP = "BOTTOM",
 	BOTTOM = "TOP",
@@ -1101,6 +1104,18 @@ function E:Initialize()
 	self:RefreshModulesDB()
 	collectgarbage("collect");
 
+	-- hackfix for filters with spell ids
+	for _,filter in pairs(self.global.unitframe["aurafilters"]) do
+		for spell,_ in pairs(filter["spells"]) do
+			if type(spell) == "number" then
+				local name = GetSpellInfo(spell)
+				if name then
+					self.spellnametoid[name] = spell
+				end
+			end
+		end
+	end
+	
 	if(self.db.general.loginmessage) then
 	--	print(select(2, E:GetModule("Chat"):FindURL("CHAT_MSG_DUMMY", format(L["LOGIN_MSG"], self["media"].hexvaluecolor, self["media"].hexvaluecolor, self.version)))..".");
 	end

--- a/ElvUI/modules/unitframes/elements/aurabars.lua
+++ b/ElvUI/modules/unitframes/elements/aurabars.lua
@@ -185,6 +185,7 @@ function UF:AuraBarFilter(unit, name, _, _, _, debuffType, duration)
 	local anotherFilterExists = false;
 	local playerOnlyFilter = false;
 	local isFriend = UnitIsFriend("player", unit) == 1 and true or false;
+	local spellID = E.spellnametoid[name]
 
 	if(UF:CheckFilter(db.playerOnly, isFriend)) then
 		if(not db.additionalFilterAllowNonPersonal) then

--- a/ElvUI/modules/unitframes/elements/auras.lua
+++ b/ElvUI/modules/unitframes/elements/auras.lua
@@ -426,6 +426,7 @@ function UF:AuraFilter(unit, icon, name, _, _, _, dtype, duration)
 	local returnValue = true;
 	local anotherFilterExists = false;
 	local isFriend = UnitIsFriend("player", unit) == 1 and true or false;
+	local spellID = E.spellnametoid[name]
 
 	icon.name = name;
 	icon.priority = 0;

--- a/ElvUI_Config/filters.lua
+++ b/ElvUI_Config/filters.lua
@@ -9,6 +9,17 @@ local tonumber = tonumber;
 local format = string.format;
 local UNKNOWN = UNKNOWN;
 
+-- TBC spell id filter fix
+local _GetSpellInfo = GetSpellInfo
+local function GetSpellInfo(id)
+	local name = _GetSpellInfo(id)
+	if name then
+		E.spellnametoid[name] = id
+		return name
+	end
+	return nil
+end
+
 local function UpdateFilterGroup()
 	E.Options.args.filters.args.filterGroup = nil;
 	E.Options.args.filters.args.spellGroup = nil;


### PR DESCRIPTION
Filters with spell IDs are currently not working at all, because UnitBuff does not return a spell id in 2.4.3

This fix caches all used spell ids for spellnames so that buffs can be matched against IDs as well.