### PR TITLE
Threat display

### DIFF
--- a/!Compatibility/api/wowAPI.lua
+++ b/!Compatibility/api/wowAPI.lua
@@ -19,6 +19,8 @@ local TIMEMANAGER_PM = TIMEMANAGER_PM
 -- Libs
 local LBC = LibStub("LibBabble-Class-3.0"):GetLookupTable()
 local LBZ = LibStub("LibBabble-Zone-3.0"):GetLookupTable()
+local LibBanzai = LibStub("LibBanzai-2.0")
+LibBanzai:RegisterCallback(function() end) -- doesn't work if 0 callbacks are registered
 
 CLASS_SORT_ORDER = {
 	"WARRIOR",
@@ -279,6 +281,74 @@ local threatColors = {
 	[2] = {1, 0.6, 0},
 	[3] = {1, 0, 0}
 }
+
+local ThreatLib = LibStub("Threat-2.0", true)
+function UnitThreatSituation(unit, targetUnit)
+	if not ThreatLib then
+		ThreatLib = LibStub("Threat-2.0", true)
+	end
+
+	if otherUnit then
+		-- specific targetUnit
+		if not UnitCanAttack(unit, targetUnit) then
+			return nil
+		end
+
+		local UnitHasAggro = UnitIsUnit(unit, targetUnit.."target")
+
+		if not ThreatLib then
+			if UnitHasAggro then return 3 else return 0 end
+		else
+			local unitGuid = UnitGUID(unit)
+			if UnitHasAggro then
+				if select(2, ThreatLib:GetMaxThreatOnTarget(targetGUID)) == unitGuid then
+					return 3
+				else
+					return 2
+				end
+			else
+				if ThreatLib:GetThreat(unitGuid, targetGUID) > ThreatLib:GetThreat(UnitGUID(targetUnit.."target"), targetGUID) then
+					return 1
+				else
+					return 0
+				end
+			end
+		end
+	else
+		-- any/all enemy units
+		local UnitHasAggro = LibBanzai:GetUnitAggroByUnitId(unit)
+
+		if not ThreatLib then
+			if UnitHasAggro then return 3 else return 0 end
+		else
+			local unitGuid = UnitGUID(unit)
+
+			local UnitHasMaxThreatOnOneTarget = false
+			for targetGUID,_ in ThreatLib:IteratePlayerThreat(unitGuid) do
+				if select(2, ThreatLib:GetMaxThreatOnTarget(targetGUID)) == unitGuid then
+					UnitHasMaxThreatOnOneTarget = true
+					break
+				end
+			end
+
+			if UnitHasAggro then
+				if UnitHasMaxThreatOnOneTarget then
+					return 3
+				else
+					return 2
+				end
+			else
+				-- Caveat: we also need to return 1 if unit has higher threat than tank, not only if unit has max threat
+				-- I have not found an efficient way to do this
+				if UnitHasMaxThreatOnOneTarget then
+					return 1
+				else
+					return 0
+				end
+			end
+		end
+	end
+end
 
 function GetThreatStatusColor(statusIndex)
 	assert(statusIndex and type(statusIndex) == "number", "Usage: GetThreatStatusColor(statusIndex)")

--- a/!Compatibility/libs/LibBanzai-2.0.lua
+++ b/!Compatibility/libs/LibBanzai-2.0.lua
@@ -1,0 +1,243 @@
+--[[
+Name: LibBanzai-2.0
+Revision: $Revision: 35 $
+Author(s): Rabbit (rabbit.magtheridon@gmail.com), maia
+Documentation: http://www.wowace.com/index.php/Banzai-2.0_API_Documentation
+SVN: http://svn.wowace.com/wowace/trunk/BanzaiLib/Banzai-2.0
+Description: Aggro notification library.
+Dependencies: LibStub
+]]
+
+-------------------------------------------------------------------------------
+-- Locals
+-------------------------------------------------------------------------------
+
+local MAJOR_VERSION = "LibBanzai-2.0"
+local MINOR_VERSION = 90000 + tonumber(("$Revision: 35 $"):match("(%d+)"))
+
+if not LibStub then error(MAJOR_VERSION .. " requires LibStub.") end
+local lib = LibStub:NewLibrary(MAJOR_VERSION, MINOR_VERSION)
+if not lib then return end
+
+lib.callbacks = lib.callbacks or {}
+local callbacks = lib.callbacks
+lib.frame = lib.frame or CreateFrame("Frame")
+local frame = lib.frame
+
+local _G = _G
+local table_insert = table.insert
+local UnitExists = _G.UnitExists
+local UnitName = _G.UnitName
+local UnitCanAttack = _G.UnitCanAttack
+local GetNumRaidMembers = _G.GetNumRaidMembers
+local GetNumPartyMembers = _G.GetNumPartyMembers
+local unpack = _G.unpack
+local type = _G.type
+local assert = _G.assert
+
+-------------------------------------------------------------------------------
+-- Local heap
+-------------------------------------------------------------------------------
+
+local new, del
+do
+	local cache = setmetatable({},{__mode='k'})
+	function new()
+		local t = next(cache)
+		if t then
+			cache[t] = nil
+			return t
+		else
+			return {}
+		end
+	end
+	function del(t)
+		for k in pairs(t) do
+			t[k] = nil
+		end
+		cache[t] = true
+		return nil
+	end
+end
+
+-------------------------------------------------------------------------------
+-- Roster
+-------------------------------------------------------------------------------
+
+local raidUnits = setmetatable({}, {__index =
+	function(self, key)
+		self[key] = ("raid%d"):format(key)
+		return self[key]
+	end
+})
+local raidPetUnits = setmetatable({}, {__index =
+	function(self, key)
+		self[key] = ("raidpet%d"):format(key)
+		return self[key]
+	end
+})
+local partyUnits = {"party1","party2","party3","party4"}
+local partyPetUnits = {"partypet1","partypet2","partypet3","partypet4"}
+local roster = {}
+local needsUpdate = nil
+
+-- If some pet has the same name as a person in the raid, they'll end up being
+-- the same unit for the purposes of banzai, but we won't care right now.
+local function addUnit(unit)
+	if not UnitExists(unit) then return end
+	local name = UnitName(unit)
+	if not roster[name] then roster[name] = new() end
+	table_insert(roster[name], unit)
+end
+
+local function actuallyUpdateRoster()
+	for k in pairs(roster) do roster[k] = del(roster[k]) end
+	addUnit("player")
+	addUnit("pet")
+	addUnit("focus")
+	for i = 1, GetNumRaidMembers() do
+		addUnit(raidUnits[i])
+		addUnit(raidPetUnits[i])
+	end
+	for i = 1, GetNumPartyMembers() do
+		addUnit(partyUnits[i])
+		addUnit(partyPetUnits[i])
+	end
+	needsUpdate = nil
+end
+
+local function updateRoster()
+	needsUpdate = true
+end
+
+-------------------------------------------------------------------------------
+-- Banzai
+-------------------------------------------------------------------------------
+
+local targets = setmetatable({}, {__index =
+	function(self, key)
+		self[key] = key .. "target"
+		return self[key]
+	end
+})
+
+local aggro = {}
+local banzai = {}
+
+local total = 0
+local function updateBanzai(_, elapsed)
+	total = total + elapsed
+	if total > 0.2 then
+		if needsUpdate then actuallyUpdateRoster() end
+		for name, units in pairs(roster) do
+			local unit = units[1]
+			local targetId = targets[unit]
+			if UnitExists(targetId) then
+				local ttId = targets[targetId]
+				if UnitExists(ttId) and UnitCanAttack(ttId, targetId) then
+					for n, u in pairs(roster) do
+						if UnitIsUnit(u[1], ttId) then
+							banzai[n] = (banzai[n] or 0) + 10
+							break
+						end
+					end
+				end
+			end
+			if banzai[name] then
+				if banzai[name] >= 5 then banzai[name] = banzai[name] - 5 end
+				if banzai[name] > 25 then banzai[name] = 25 end
+			end
+		end
+		for name, units in pairs(roster) do
+			if banzai[name] and banzai[name] > 15 then
+				if not aggro[name] then
+					aggro[name] = true
+					for i, v in ipairs(callbacks) do
+						v(1, name, unpack(units))
+					end
+				end
+			elseif aggro[name] then
+				aggro[name] = nil
+				for i, v in ipairs(callbacks) do
+					v(0, name, unpack(units))
+				end
+			end
+		end
+		total = 0
+	end
+end
+
+-------------------------------------------------------------------------------
+-- Starting and stopping
+-------------------------------------------------------------------------------
+
+local running = nil
+local function start()
+	if running then return end
+	updateRoster()
+	frame:SetScript("OnUpdate", updateBanzai)
+	frame:SetScript("OnEvent", updateRoster)
+	frame:RegisterEvent("RAID_ROSTER_UPDATE")
+	frame:RegisterEvent("PARTY_MEMBERS_CHANGED")
+	frame:RegisterEvent("UNIT_PET")
+	frame:RegisterEvent("PLAYER_FOCUS_CHANGED")
+	running = true
+end
+
+local function stop()
+	if not running then return end
+	frame:SetScript("OnUpdate", nil)
+	frame:SetScript("OnEvent", nil)
+	frame:UnregisterAllEvents()
+	running = nil
+end
+
+-------------------------------------------------------------------------------
+-- API
+-------------------------------------------------------------------------------
+
+function lib:IsRunning() return running end
+function lib:GetUnitAggroByUnitName(name) return aggro[name] end
+function lib:GetUnitAggroByUnitId(unit)
+	if not UnitExists(unit) then return end
+	return aggro[UnitName(unit)]
+end
+
+function lib:RegisterCallback(func)
+	if type(func) ~= "function" then
+		error(("Bad argument to :RegisterCallback, function expected, got %q."):format(type(func)), 2)
+	end
+
+	table_insert(callbacks, func)
+	start()
+end
+
+function lib:UnregisterCallback(func)
+	if type(func) ~= "function" then
+		error(("Bad argument to :UnregisterCallback, function expected, got %q."):format(type(func)), 2)
+	end
+
+	local found = nil
+	for i, v in ipairs(callbacks) do
+		if v == func then
+			table.remove(callbacks, i)
+			found = true
+			break
+		end
+	end
+	if #callbacks == 0 then stop() end
+
+	if not found then
+		error("Bad argument to :UnregisterCallback, the provided function was not registered.", 2)
+	end
+end
+
+-------------------------------------------------------------------------------
+-- Initialization
+-------------------------------------------------------------------------------
+
+frame:SetScript("OnUpdate", nil)
+frame:SetScript("OnEvent", nil)
+frame:UnregisterAllEvents()
+if #callbacks > 0 then start() end
+

--- a/!Compatibility/libs/libs.xml
+++ b/!Compatibility/libs/libs.xml
@@ -3,4 +3,5 @@
 	<Script file="LibBabble-3.0.lua"/>
 	<Script file="LibBabble-Class-3.0.lua"/>
 	<Script file="LibBabble-Zone-3.0.lua"/>
+	<Script file="LibBanzai-2.0.lua"/>
 </Ui>

--- a/ElvUI/Libraries/oUF/elements/threatindicator.lua
+++ b/ElvUI/Libraries/oUF/elements/threatindicator.lua
@@ -1,0 +1,134 @@
+--[[
+# Element: Threat Indicator
+
+Handles the visibility and updating of an indicator based on the unit's current threat level.
+
+## Widget
+
+ThreatIndicator - A `Texture` used to display the current threat level.
+The element works by changing the texture's vertex color.
+
+## Notes
+
+A default texture will be applied if the widget is a Texture and doesn't have a texture or a color set.
+
+## Options
+
+.feedbackUnit - The unit whose threat situation is being requested. If defined, it'll be passed as the first argument to
+                [GetThreatStatusColor](http://wowprogramming.com/docs/api/UnitThreatSituation).
+
+## Examples
+
+    -- Position and size
+    local ThreatIndicator = self:CreateTexture(nil, 'OVERLAY')
+    ThreatIndicator:SetSize(16, 16)
+    ThreatIndicator:SetPoint('TOPRIGHT', self)
+
+    -- Register it with oUF
+    self.ThreatIndicator = ThreatIndicator
+--]]
+
+local _, ns = ...
+local oUF = ns.oUF
+
+local GetThreatStatusColor = GetThreatStatusColor
+local UnitExists = UnitExists
+local UnitThreatSituation = UnitThreatSituation
+
+local function Update(self, event, unit)
+	if(not unit or self.unit ~= unit) then return end
+
+	local element = self.ThreatIndicator
+	--[[ Callback: ThreatIndicator:PreUpdate(unit)
+	Called before the element has been updated.
+
+	* self - the ThreatIndicator element
+	* unit - the unit for which the update has been triggered (string)
+	--]]
+	if(element.PreUpdate) then element:PreUpdate(unit) end
+
+	local feedbackUnit = element.feedbackUnit
+	unit = unit or self.unit
+
+	local status
+	-- BUG: Non-existent '*target' or '*pet' units cause UnitThreatSituation() errors
+	if(UnitExists(unit)) then
+		if(feedbackUnit and feedbackUnit ~= unit and UnitExists(feedbackUnit)) then
+			status = UnitThreatSituation(feedbackUnit, unit)
+		else
+			status = UnitThreatSituation(unit)
+		end
+	end
+
+	local r, g, b
+	if(status and status > 0) then
+		r, g, b = GetThreatStatusColor(status)
+
+		if(element.SetVertexColor) then
+			element:SetVertexColor(r, g, b)
+		end
+
+		element:Show()
+	else
+		element:Hide()
+	end
+
+	--[[ Callback: ThreatIndicator:PostUpdate(unit, status, r, g, b)
+	Called after the element has been updated.
+
+	* self   - the ThreatIndicator element
+	* unit   - the unit for which the update has been triggered (string)
+	* status - the unit's threat status (see [UnitThreatSituation](http://wowprogramming.com/docs/api/UnitThreatSituation))
+	* r      - the red color component based on the unit's threat status (number?)[0-1]
+	* g      - the green color component based on the unit's threat status (number?)[0-1]
+	* b      - the blue color component based on the unit's threat status (number?)[0-1]
+	--]]
+	if(element.PostUpdate) then
+		return element:PostUpdate(unit, status, r, g, b)
+	end
+end
+
+local function Path(self, ...)
+	--[[ Override: ThreatIndicator.Override(self, event, ...)
+	Used to completely override the internal update function.
+
+	* self  - the parent object
+	* event - the event triggering the update (string)
+	* ...   - the arguments accompanying the event
+	--]]
+	return (self.ThreatIndicator.Override or Update) (self, ...)
+end
+
+local function ForceUpdate(element)
+	return Path(element.__owner, 'ForceUpdate', element.__owner.unit)
+end
+
+local function Enable(self)
+	local element = self.ThreatIndicator
+	if(element) then
+		element.__owner = self
+		element.ForceUpdate = ForceUpdate
+
+		self:RegisterEvent('UNIT_THREAT_SITUATION_UPDATE', Path)
+		self:RegisterEvent('UNIT_THREAT_LIST_UPDATE', Path)
+
+		if(element:IsObjectType('Texture') and not element:GetTexture()) then
+			element:SetTexture([[Interface\Minimap\ObjectIcons]])
+			element:SetTexCoord(6/8, 7/8, 1/8, 2/8)
+		end
+
+		return true
+	end
+end
+
+local function Disable(self)
+	local element = self.ThreatIndicator
+	if(element) then
+		element:Hide()
+
+		self:UnregisterEvent('UNIT_THREAT_SITUATION_UPDATE', Path)
+		self:UnregisterEvent('UNIT_THREAT_LIST_UPDATE', Path)
+	end
+end
+
+oUF:AddElement('ThreatIndicator', Path, Enable, Disable)

--- a/ElvUI/Libraries/oUF/oUF.xml
+++ b/ElvUI/Libraries/oUF/oUF.xml
@@ -21,6 +21,7 @@
 	<Script file="elements\range.lua"/>
 	<Script file="elements\castbar.lua"/>
 	<Script file="elements\tags.lua"/>
+	<Script file="elements\threatindicator.lua"/>
 	<Script file="elements\masterlooterindicator.lua"/>
 	<Script file="elements\assistantindicator.lua"/>
 	<Script file="elements\readycheckindicator.lua"/>


### PR DESCRIPTION
Threat display functionality was removed some time ago, presumably because UnitThreatSituation etc. are not present in 2.4.3.

I have implemented UnitThreatSituation using LibBanzai-2.0 and ThreatLib-2.0. Works surprisingly good!

The uOF threat element uses UNIT_THREAT_SITUATION_UPDATE, UNIT_THREAT_LIST_UPDATE which are also not present in 2.4.3. I replaced those with callbacks also from LibBanzai and ThreatLib. Works fine as well. ThreatLib callbacks are rate-limited (2 per second).

WIP, because I have not tested this in a raid yet. There are some debug prints still. Will report here again.