### PR TITLE
Fix delayed update of power bar text (mana/rage/energy)

### DIFF
--- a/ElvUI/modules/unitframes/elements/power.lua
+++ b/ElvUI/modules/unitframes/elements/power.lua
@@ -26,7 +26,6 @@ function UF:Construct_PowerBar(frame, bg, text, textPos)
 
 	if(text) then
 		power.value = frame.RaisedElementParent:CreateFontString(nil, "OVERLAY");
-		power.value.frequentUpdates = true;
 
 		UF:Configure_FontString(power.value);
 


### PR DESCRIPTION
According to documentation, the frequentUpdates setting "will override the events for the tag(s), if any".
https://github.com/ElvUI-TBC/ElvUI/blob/master/ElvUI/Libraries/oUF/elements/tags.lua#L40
A non-event-based update is obviously not desirable for power..