### PR TITLE
Skins: Fix Blizzard Trainer dialog error

### DIFF
--- a/ElvUI/modules/skins/blizzard/trainer.lua
+++ b/ElvUI/modules/skins/blizzard/trainer.lua
@@ -86,6 +86,8 @@ local function LoadSkin()
 	ClassTrainerSkillHighlightFrame.Right:SetTexture(E.media.blankTex)
 
 	hooksecurefunc("ClassTrainer_SetSelection", function(id)
+		if not id then return; end -- We are often called without an id (nothing to skin in that case).
+
 		local skillIcon = ClassTrainerSkillIcon:GetNormalTexture()
 
 		if skillIcon and not skillIcon.isSkinned then


### PR DESCRIPTION
The "ClassTrainer_SetSelection" is called a lot with no "id" in TBC's
WoW client. In that case, we should do nothing, since there's nothing to
skin. This solves the unrecoverable Lua error introduced recently.