### PR TITLE
Bugfix: Send correct parameters to CreateMover

### DIFF
--- a/ElvUI/core/movers.lua
+++ b/ElvUI/core/movers.lua
@@ -509,7 +509,9 @@ end
 
 --Called from core.lua
 function E:LoadMovers()
-	for n, t in pairs(E.CreatedMovers) do
-		CreateMover(t.parent, n, t.overlay, t.snapoffset, t.postdrag, t.shouldDisable, t.configString)
+	for name, t in pairs(E.CreatedMovers) do
+		--All of these properties are cached in E.CreatedMovers by "E:CreateMover()",
+		--so that we can reproduce the function calls identically here.
+		CreateMover(t.parent, name, t.text, t.overlay, t.snapoffset, t.postdrag, t.shouldDisable, t.configString)
 	end
 end


### PR DESCRIPTION
The "E:LoadMovers()" call to the local function "CreateMover()"
was missing its "text" parameter (3rd parameter), which meant that
all subsequent function calls via LoadMovers submitted corrupted
function parameters.

However, the proper value for the "text" parameter IS being saved by
"E:CreateMover()", so we HAVE everything we needed to fix the bug. We
simply have to pass the t.text value in the call!