### PR TITLE
Bugfix: Don't crash when frames lack castbar table

### DIFF
--- a/ElvUI/modules/unitframes/elements/castbar.lua
+++ b/ElvUI/modules/unitframes/elements/castbar.lua
@@ -100,7 +100,7 @@ function UF:Configure_Castbar(frame)
 	local castbar = frame.Castbar
 	local db = frame.db
 
-	if db.castbar.enable then
+	if db.castbar and db.castbar.enable then
 		if not frame:IsElementEnabled("Castbar") then
 			frame:EnableElement("Castbar")
 		end


### PR DESCRIPTION
The code assumed that every frame always had a "castbar" table, and
then it checked "if db.castbar.enable"... (db = the frame's table).

That failed and caused Lua errors (and aborted the profile loading)
since the "castbar" table does *not* always exist, thus causing an
"attempt to access nil field" error.

Fixed to first verify that a "castbar" table exists before attempting
to check if the "enable" property exists!

---

Here's a typical example of a unitframe with no "castbar" table:

```
    ["player"] = {
            ["swingbar"] = {
                    ["color"] = {
                            ["b"] = 0.6470588235294118,
                            ["g"] = 0.6,
                            ["r"] = 0.1686274509803922,
                    },
                    ["text"] = {
                            ["font"] = "PT Sans Narrow",
                            ["fontSize"] = 14,
                            ["fontOutline"] = "OUTLINE",
                    },
            },
            ["aurabar"] = {
                    ["maxBars"] = 4,
            },
            ["power"] = {
                    ["height"] = 14,
            },
            ["raidicon"] = {
                    ["attachTo"] = "RIGHT",
                    ["size"] = 26,
                    ["xOffset"] = 29,
                    ["yOffset"] = 12,
            },
    },
```