### PR TITLE
ActionBars: Fix right-click self-cast option not persisting

### DIFF
--- a/ElvUI/modules/actionbars/actionbars.lua
+++ b/ElvUI/modules/actionbars/actionbars.lua
@@ -695,7 +695,7 @@ function AB:UpdateButtonConfig(bar, buttonName)
 		button:SetAttribute("checkselfcast", true)
 		button:SetAttribute("checkfocuscast", true)
 		if self.db.rightClickSelfCast then
-			E:Delay(0.1, bar:SetAttribute("unit-S"..(bar:GetAttribute("state-page") or 0).."Right", "player"))
+			E:Delay(0.1, function() bar:SetAttribute("unit-S"..(bar:GetAttribute("state-page") or 0).."Right", "player") end)
 		else
 			bar:SetAttribute("unit-S"..(bar:GetAttribute("state-page") or 0).."Right")
 		end


### PR DESCRIPTION
Not sure if you guys are still around, but here's a small fix :)

The call to `bar:SetAttribute` was not actually delayed, it was just called immediately and E:Delay() returned false. Hence it only worked when manually setting, not on login or reload, where it has to be delayed.